### PR TITLE
Fix I18N

### DIFF
--- a/hello-stable/snapcraft.yaml
+++ b/hello-stable/snapcraft.yaml
@@ -7,7 +7,7 @@ confinement: strict
 
 apps:
   hello:
-    command: hello
+    command: locales-launch hello
   universe:
     command: hello -g \"Hello, universe!\"
 
@@ -15,4 +15,9 @@ parts:
   gnu-hello:
     plugin: autotools
     source: http://ftp.gnu.org/gnu/hello/hello-2.10.tar.gz
+    configflags:
+    - --datarootdir=/snap/$SNAPCRAFT_PROJECT_NAME/current/share
+    organize:
+      snap/$SNAPCRAFT_PROJECT_NAME/current: /
 
+  locales-launch:


### PR DESCRIPTION
This patch fixes missing I18N due to unavailable glibc locales data and
wrong path of the gettext translation files.

Refer the following forum topic for more information about the fix:

    The `locales-launch` remote part - doc - snapcraft.io
    https://forum.snapcraft.io/t/the-locales-launch-remote-part/8729

The other channels are not fixed, as they uses custom messages that will
not benefit from fixing I18N anyway.

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>